### PR TITLE
expose symfony services directly from the zf service locator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,16 @@ return [
 
 # Usage
 
-To retrieve the symfony container a zend controller:
+Any existing service will directly be available through the Service Manager of Zend:
+
+```php
+<?php
+
+$service = $this->getServiceLocator()->get(\My\Public\Service::class);
+```
+
+But you can also retrieve the symfony container:
+
 
 ```php
 <?php

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Adlogix\ZfSymfonyContainer\Service\Factory\SymfonyContainerAbstractFactory;
 use Adlogix\ZfSymfonyContainer\Service\Factory\SymfonyContainerConfigFactory;
 use Adlogix\ZfSymfonyContainer\Service\Factory\SymfonyContainerFactory;
 
@@ -43,8 +44,12 @@ return [
 
     'service_manager' => [
 
+        'abstract_factories' => [
+            SymfonyContainerAbstractFactory::class
+        ],
+
         'factories' => [
-            'zf_symfony_container'        => SymfonyContainerFactory::class,
+            'zf_symfony_container' => SymfonyContainerFactory::class,
             'zf_symfony_container_config' => SymfonyContainerConfigFactory::class,
         ]
 

--- a/src/Service/Factory/SymfonyContainerAbstractFactory.php
+++ b/src/Service/Factory/SymfonyContainerAbstractFactory.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * This file is part of the Adlogix package.
+ *
+ * (c) Allan Segebarth <allan@adlogix.eu>
+ * (c) Jean-Jacques Courtens <jjc@adlogix.eu>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Adlogix\ZfSymfonyContainer\Service\Factory;
+
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Zend\ServiceManager\AbstractFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * @author Toni Van de Voorde <toni@adlogix.eu>
+ */
+final class SymfonyContainerAbstractFactory implements AbstractFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function canCreateServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        /** @var ContainerInterface $sfContainer */
+        $sfContainer = $serviceLocator->get('zf_symfony_container');
+
+        return $sfContainer->has($requestedName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createServiceWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName)
+    {
+        /** @var ContainerInterface $sfContainer */
+        $sfContainer = $serviceLocator->get('zf_symfony_container');
+
+        return $sfContainer->get($requestedName);
+    }
+}

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+chdir(dirname(__DIR__));
+
 ini_set('error_reporting', E_ALL);
 
 $files = [__DIR__ . '/../vendor/autoload.php'];

--- a/tests/Service/Factory/SymfonyContainerAbstractFactoryTest.php
+++ b/tests/Service/Factory/SymfonyContainerAbstractFactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This file is part of the Adlogix package.
+ *
+ * (c) Allan Segebarth <allan@adlogix.eu>
+ * (c) Jean-Jacques Courtens <jjc@adlogix.eu>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Adlogix\ZfSymfonyContainer\Test\Service\Factory;
+
+
+use Adlogix\ZfSymfonyContainer\Test\Fixtures\DummyTwo;
+use Adlogix\ZfSymfonyContainer\Test\Util\ServiceManagerFactory;
+use PHPUnit\Framework\TestCase;
+
+final class SymfonyContainerAbstractFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getService_directlyThroughServiceLocator_shouldReturnInstance()
+    {
+        $dummyTwo = ServiceManagerFactory::getServiceManager()
+            ->get(DummyTwo::class);
+
+        $this->assertInstanceOf(DummyTwo::class, $dummyTwo);
+    }
+}


### PR DESCRIPTION
Before it was required to first get the symfony container to access the services. Now, you can directly extract it from the zend service locator which will proxy to the symfony container service.

**Before**
```
<?php
$container = $this->getServiceLocator()->get('zf_symfony_container');
$service = $container->get(\My\Public\Service::class);
```
**Now**
```
<?php
$service = $this->getServiceLocator()->get(\My\Public\Service::class);
```