### PR TITLE
use the zend config into the Symfony container

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,50 +103,34 @@ $container = $this->getServiceLocator()->get('zf_symfony_container');
 ```
 
 #### Use the Zend config as Symfony parameters
-The Zend config is translated into Symfony parameter. Please refer to the documentation of [Symfony parameters](https://symfony.com/doc/current/service_container/parameters.html) for more information.
-Each level of the Zend config is concatenate with a '.'. 
-
-By example this Zend configuration:  
+The module takes care of transforming all zend configurations into [Symfony parameters](https://symfony.com/doc/current/service_container/parameters.html) allowing you to immediately use the parameters in the service definition file:
+```php
+<?php
+// global.php
+return [
+    'myconfig' => 'hello world' 
+];
 ```
-[
- 'zf_symfony_container' => [
- 
-         // directory where to look for the service container configurations (e.g. config/services.yaml)
-         'config_dir' => 'config',
- 
-         // Caching options
-         'cache' => [
- 
-             // directory where the cached container will be stored
-             'dir' => 'data/ZfSymfonyContainer',
- 
-             // name of the file to generate the cached container class
-             'filename' => 'zf_symfony_container_cache',
- 
-             // name of the class of the generated cached container
-             'classname' => 'CachedContainer',
- 
-             // the namespace of the generated cached container
-             'namespace' => 'Adlogix\ZfSymfonyContainer\DependencyInjection',
- 
-             // enable in dev mode
-             'debug' => false
-         ],
- 
- 
-     ],
-]
+```yaml
+services:
+  Some\Service:
+    arguments: ['%myconfig%']
 ```
-
-Will give these parameters:
+When the Zend configuration contains deep level keys, the "keys" will be concatenated with a dot.
+```php
+<?php
+// global.php
+return [
+    'deep' => [
+        'level' => [
+            'config' => 'hello world'            
+        ]    
+    ]    
+];
 ```
-parameters:
-    zf_symfony_container.config_dir: 'config'
-    zf_symfony_container.cache.dir: 'data/ZfSymfonyContainer'
-    zf_symfony_container.cache.filename: 'zf_symfony_container_cache'
-    zf_symfony_container.cache.classname: 'CachedContainer'
-    zf_symfony_container.cache.namespace: 'Adlogix\ZfSymfonyContainer\DependencyInjection'
-    zf_symfony_container.cache.debug: false
+```yaml
+services:
+  Some\Service:
+    arguments: ['%deep.level.config%']
 ```
-
-All callbacks are ignored.
+_Note: zend configurations using callables will be ignored and cannot be used!_ 

--- a/README.md
+++ b/README.md
@@ -101,3 +101,52 @@ the Zend Service Manager.
 
 $container = $this->getServiceLocator()->get('zf_symfony_container');
 ```
+
+#### Use the Zend config as Symfony parameters
+The Zend config is translated into Symfony parameter. Please refer to the documentation of [Symfony parameters](https://symfony.com/doc/current/service_container/parameters.html) for more information.
+Each level of the Zend config is concatenate with a '.'. 
+
+By example this Zend configuration:  
+```
+[
+ 'zf_symfony_container' => [
+ 
+         // directory where to look for the service container configurations (e.g. config/services.yaml)
+         'config_dir' => 'config',
+ 
+         // Caching options
+         'cache' => [
+ 
+             // directory where the cached container will be stored
+             'dir' => 'data/ZfSymfonyContainer',
+ 
+             // name of the file to generate the cached container class
+             'filename' => 'zf_symfony_container_cache',
+ 
+             // name of the class of the generated cached container
+             'classname' => 'CachedContainer',
+ 
+             // the namespace of the generated cached container
+             'namespace' => 'Adlogix\ZfSymfonyContainer\DependencyInjection',
+ 
+             // enable in dev mode
+             'debug' => false
+         ],
+ 
+ 
+     ],
+]
+```
+
+Will give these parameters:
+```
+parameters:
+    zf_symfony_container.config_dir: 'config'
+    zf_symfony_container.cache.dir: 'data/ZfSymfonyContainer'
+    zf_symfony_container.cache.filename: 'zf_symfony_container_cache'
+    zf_symfony_container.cache.classname: 'CachedContainer'
+    zf_symfony_container.cache.namespace: 'Adlogix\ZfSymfonyContainer\DependencyInjection'
+    zf_symfony_container.cache.debug: false
+```
+
+All callbacks are ignored.

--- a/src/ParameterBag/ZendFrameworkParameterBag.php
+++ b/src/ParameterBag/ZendFrameworkParameterBag.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This file is part of the Adlogix package.
+ *
+ * (c) Allan Segebarth <allan@adlogix.eu>
+ * (c) Jean-Jacques Courtens <jjc@adlogix.eu>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Adlogix\ZfSymfonyContainer\ParameterBag;
+
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+/**
+ * Translate the ZF config into Symfony parameters.
+ *
+ * @author Laurent De Coninck <laurent@adlogix.eu>
+ */
+class ZendFrameworkParameterBag extends ParameterBag
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function add(array $parameters)
+    {
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
+                $this->addChildren($key, $value);
+                continue;
+            }
+
+            if (is_callable($value)) {
+                //not supported by Symfony
+                continue;
+            }
+
+            $this->set($key, str_replace('%', '%%', $value));
+        }
+    }
+
+    /**
+     * @param string $previousKey
+     * @param array  $children
+     */
+    private function addChildren($previousKey, array $children)
+    {
+        $formattedChildren = [];
+
+        foreach ($children as $key => $value) {
+            $formattedChildren[$previousKey . '.' . $key] = $value;
+        }
+
+        $this->add($formattedChildren);
+    }
+}

--- a/src/Service/Factory/SymfonyContainerFactory.php
+++ b/src/Service/Factory/SymfonyContainerFactory.php
@@ -12,6 +12,7 @@
 namespace Adlogix\ZfSymfonyContainer\Service\Factory;
 
 use Adlogix\ZfSymfonyContainer\Options\Configuration;
+use Adlogix\ZfSymfonyContainer\ParameterBag\ZendFrameworkParameterBag;
 use Interop\Container\ContainerInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
@@ -31,13 +32,13 @@ final class SymfonyContainerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator, SymfonyContainerFactory::class);
+        return $this($serviceLocator, SymfonyContainerFactory::class, $serviceLocator->get('config'));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __invoke(ContainerInterface $zfContainer, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $zfContainer, $requestedName, array $config = null)
     {
         /** @var Configuration $configuration */
         $configuration = $zfContainer->get('zf_symfony_container_config');
@@ -47,7 +48,7 @@ final class SymfonyContainerFactory implements FactoryInterface
         $containerConfigCache = new ConfigCache($cachedFilePath, $configuration->isDebug());
 
         if (!$containerConfigCache->isFresh()) {
-            $containerBuilder = new ContainerBuilder();
+            $containerBuilder = new ContainerBuilder(new ZendFrameworkParameterBag($config));
             $loader = new YamlFileLoader($containerBuilder, new FileLocator([$configuration->getConfigDir()]));
             $loader->load('services.yaml');
 

--- a/src/Service/Factory/SymfonyContainerFactory.php
+++ b/src/Service/Factory/SymfonyContainerFactory.php
@@ -32,13 +32,13 @@ final class SymfonyContainerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator, SymfonyContainerFactory::class, $serviceLocator->get('config'));
+        return $this($serviceLocator, SymfonyContainerFactory::class);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function __invoke(ContainerInterface $zfContainer, $requestedName, array $config = null)
+    public function __invoke(ContainerInterface $zfContainer, $requestedName, array $options = null)
     {
         /** @var Configuration $configuration */
         $configuration = $zfContainer->get('zf_symfony_container_config');
@@ -48,7 +48,8 @@ final class SymfonyContainerFactory implements FactoryInterface
         $containerConfigCache = new ConfigCache($cachedFilePath, $configuration->isDebug());
 
         if (!$containerConfigCache->isFresh()) {
-            $containerBuilder = new ContainerBuilder(new ZendFrameworkParameterBag($config));
+            $zfConfig = $zfContainer->get('config');
+            $containerBuilder = new ContainerBuilder(new ZendFrameworkParameterBag($zfConfig));
             $loader = new YamlFileLoader($containerBuilder, new FileLocator([$configuration->getConfigDir()]));
             $loader->load('services.yaml');
 

--- a/tests/ParameterBag/ZendFrameworkParameterBagTest.php
+++ b/tests/ParameterBag/ZendFrameworkParameterBagTest.php
@@ -1,6 +1,12 @@
 <?php
 /**
+ * This file is part of the Adlogix package.
  *
+ * (c) Allan Segebarth <allan@adlogix.eu>
+ * (c) Jean-Jacques Courtens <jjc@adlogix.eu>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Adlogix\ZfSymfonyContainer\Test\ParameterBag;

--- a/tests/ParameterBag/ZendFrameworkParameterBagTest.php
+++ b/tests/ParameterBag/ZendFrameworkParameterBagTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ *
+ */
+
+namespace Adlogix\ZfSymfonyContainer\Test\ParameterBag;
+
+use Adlogix\ZfSymfonyContainer\ParameterBag\ZendFrameworkParameterBag;
+
+/**
+ * @author Laurent De Coninck <lau.deconinck@gmail.com>
+ */
+class ZendFrameworkParameterBagTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @param array $parameters
+     *
+     * @return ZendFrameworkParameterBag
+     */
+    private function createParameterBag(array $parameters)
+    {
+        return new ZendFrameworkParameterBag($parameters);
+    }
+
+    /**
+     * @test
+     */
+    public function add_WithValues_Success()
+    {
+        $data = [
+            'key'        => 'value1',
+            'anotherKey' => '%value1%',
+        ];
+
+        $parameterBag = $this->createParameterBag($data);
+
+        $this->assertEquals('value1', $parameterBag->get('key'));
+        $this->assertEquals('%%value1%%', $parameterBag->get('anotherKey'));
+    }
+
+    /**
+     * @test
+     */
+    public function add_WithTables_Success()
+    {
+        $data = [
+            'key'         => 'value1',
+            'associative' => [
+                'a' => 1,
+                'c' => 2,
+                'd' => 3,
+            ],
+            'index' => [
+                'A',
+                'B',
+                'C',
+            ],
+            'arrayOfArray' => [
+                'a' => [
+                    'A',
+                    'B',
+                    'C',
+                ],
+            ],
+        ];
+
+        $parameterBag = $this->createParameterBag($data);
+        $this->assertEquals('value1', $parameterBag->get('key'));
+        $this->assertEquals(2, $parameterBag->get('associative.c'));
+        $this->assertEquals('B', $parameterBag->get('index.1'));
+        $this->assertEquals('B', $parameterBag->get('arrayOfArray.a.1'));
+    }
+
+    /**
+     * @test
+     */
+    public function add_WithCallable_Skipped()
+    {
+        $data = [
+            'callback' => function () {
+                return true;
+            },
+        ];
+
+        $parameterBag = $this->createParameterBag($data);
+
+        $this->assertFalse($parameterBag->has('callback'));
+    }
+}


### PR DESCRIPTION
With this commit it's now possible to use the ZF config into the Symfony service container.

When the system creates the Symfony container it injects the ZF config. Since ZF is using the same naming convention with a different meaning as Symfony (e.g. the %) we need to translate them before the import.